### PR TITLE
Python fine grain support

### DIFF
--- a/languages/python/tags.scm
+++ b/languages/python/tags.scm
@@ -1,18 +1,7 @@
 ; Class definitions
 (
-  (comment)? @comment
-  .
   (class_definition
     name: (identifier) @name) @tag.Class
-)
-
-; Decorated class definitions
-(
-  (comment)? @comment
-  .
-  (decorated_definition
-    (class_definition
-      name: (identifier) @name)) @tag.Class
 )
 
 ; Method definitions (functions inside classes, including __init__)
@@ -66,16 +55,6 @@
   )
 )
 
-; Module-level function definitions with comment
-(
-  (module
-    (comment)? @comment
-    .
-    (function_definition
-      name: (identifier) @name) @tag.Function
-  )
-)
-
 ; Decorated function definitions at module level
 (
   (module
@@ -85,13 +64,18 @@
   )
 )
 
-; Decorated function definitions at module level with comment
+; Fields/Variables assigned in __init__
 (
-  (module
-    (comment)? @comment
-    .
-    (decorated_definition
+  (class_definition
+    body: (block
       (function_definition
-        name: (identifier) @name)) @tag.Function
-  )
+        name: (identifier) @func_name
+        body: (block
+          (expression_statement
+            (assignment
+              left: (attribute
+                object: (identifier) @self_ref
+                attribute: (identifier) @name)))) @tag.Field)))
+  (#eq? @func_name "__init__")
+  (#eq? @self_ref "self")
 )

--- a/languages/python/tags.scm
+++ b/languages/python/tags.scm
@@ -65,6 +65,8 @@
 )
 
 ; Fields/Variables assigned in __init__
+; Tree-sitter wrap the assignment matching in expression_state in case
+; that's the only thing happening in the body
 (
   (class_definition
     body: (block
@@ -76,6 +78,21 @@
               left: (attribute
                 object: (identifier) @self_ref
                 attribute: (identifier) @name)))) @tag.Field)))
+  (#eq? @func_name "__init__")
+  (#eq? @self_ref "self")
+)
+
+; we don't wrap the match in expression_statement in case there are multiple logics
+(
+  (class_definition
+    body: (block
+      (function_definition
+        name: (identifier) @func_name
+        body: (block
+          (assignment
+            left: (attribute
+              object: (identifier) @self_ref
+              attribute: (identifier) @name))) @tag.Field)))
   (#eq? @func_name "__init__")
   (#eq? @self_ref "self")
 )

--- a/languages/python/tags.scm
+++ b/languages/python/tags.scm
@@ -1,0 +1,97 @@
+; Class definitions
+(
+  (comment)? @comment
+  .
+  (class_definition
+    name: (identifier) @name) @tag.Class
+)
+
+; Decorated class definitions
+(
+  (comment)? @comment
+  .
+  (decorated_definition
+    (class_definition
+      name: (identifier) @name)) @tag.Class
+)
+
+; Method definitions (functions inside classes, including __init__)
+; These patterns MUST come before module-level function patterns
+(
+  (class_definition
+    body: (block
+      (function_definition
+        name: (identifier) @name) @tag.Method
+    )
+  )
+)
+
+; Decorated methods inside classes (e.g., @property, @classmethod, @staticmethod)
+(
+  (class_definition
+    body: (block
+      (decorated_definition
+        (function_definition
+          name: (identifier) @name)) @tag.Method
+    )
+  )
+)
+
+; Nested functions (functions inside other functions)
+(
+  (function_definition
+    body: (block
+      (function_definition
+        name: (identifier) @name) @tag.Function
+    )
+  )
+)
+
+; Nested decorated functions
+(
+  (function_definition
+    body: (block
+      (decorated_definition
+        (function_definition
+          name: (identifier) @name)) @tag.Function
+    )
+  )
+)
+
+; Module-level function definitions (including async)
+(
+  (module
+    (function_definition
+      name: (identifier) @name) @tag.Function
+  )
+)
+
+; Module-level function definitions with comment
+(
+  (module
+    (comment)? @comment
+    .
+    (function_definition
+      name: (identifier) @name) @tag.Function
+  )
+)
+
+; Decorated function definitions at module level
+(
+  (module
+    (decorated_definition
+      (function_definition
+        name: (identifier) @name)) @tag.Function
+  )
+)
+
+; Decorated function definitions at module level with comment
+(
+  (module
+    (comment)? @comment
+    .
+    (decorated_definition
+      (function_definition
+        name: (identifier) @name)) @tag.Function
+  )
+)

--- a/languages/python/tags.scm
+++ b/languages/python/tags.scm
@@ -64,35 +64,47 @@
   )
 )
 
-; Fields/Variables assigned in __init__
-; Tree-sitter wrap the assignment matching in expression_state in case
-; that's the only thing happening in the body
+; Fields matching, use conditional to match both the single statement and multi statements cases
+; only match for attributes of a class initiated in "__init__"
 (
   (class_definition
     body: (block
       (function_definition
         name: (identifier) @func_name
         body: (block
-          (expression_statement
+          [
+            (expression_statement
+              (assignment
+                left: (attribute
+                  object: (identifier) @self_ref
+                  attribute: (identifier) @name))) @tag.Field
             (assignment
               left: (attribute
                 object: (identifier) @self_ref
-                attribute: (identifier) @name)))) @tag.Field)))
+                attribute: (identifier) @name)) @tag.Field
+          ]))))
   (#eq? @func_name "__init__")
   (#eq? @self_ref "self")
 )
 
-; we don't wrap the match in expression_statement in case there are multiple logics
+; Like the above but for case like self.x += 3 instead of self.x = 3
 (
   (class_definition
     body: (block
       (function_definition
         name: (identifier) @func_name
         body: (block
-          (assignment
-            left: (attribute
-              object: (identifier) @self_ref
-              attribute: (identifier) @name))) @tag.Field)))
+          [
+            (expression_statement
+              (augmented_assignment
+                left: (attribute
+                  object: (identifier) @self_ref
+                  attribute: (identifier) @name))) @tag.Field
+            (augmented_assignment
+              left: (attribute
+                object: (identifier) @self_ref
+                attribute: (identifier) @name)) @tag.Field
+          ]))))
   (#eq? @func_name "__init__")
   (#eq? @self_ref "self")
 )

--- a/src/core.rs
+++ b/src/core.rs
@@ -483,6 +483,8 @@ pub enum EntityKind {
     Interface,
     Method,
     Record,
+    Decorator,
+    Function,
 }
 
 impl ToSql for EntityKind {

--- a/src/core.rs
+++ b/src/core.rs
@@ -483,7 +483,6 @@ pub enum EntityKind {
     Interface,
     Method,
     Record,
-    Decorator,
     Function,
 }
 

--- a/src/languages.rs
+++ b/src/languages.rs
@@ -216,7 +216,7 @@ lazy_static! {
     static ref PYTHON: LangConfig = LangConfig::new(
         tree_sitter_python::language(),
         LANG_TABLE.pathspec(Lang::Python),
-        None,
+        Some(include_str!("../languages/python/tags.scm")),
         Some(include_str!("../languages/python/stack-graphs.tsg")),
         Some("python")
     );


### PR DESCRIPTION
Neodepends can now parse those entities in Python:
- Classes
- Methods (Functions inside classes)
- Functions
- Nested functions/classes
- Attributes of classes (only those initiated in __init__)